### PR TITLE
Also parse metadata for get-only variables

### DIFF
--- a/copy_with_generator/CHANGELOG.md
+++ b/copy_with_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## [0.1.0]
 
 * Converted to dart extension method
+
+## [0.1.1]
+
+* Check ignore for only-get props too

--- a/copy_with_generator/lib/src/copy_with_generator.dart
+++ b/copy_with_generator/lib/src/copy_with_generator.dart
@@ -53,7 +53,11 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
       final constantValue = e.computeConstantValue();
       return TypeChecker.fromRuntime(CopyWithField)
           .isExactlyType(constantValue.type);
-    }, orElse: () => null);
+    }, orElse: () => () => element.getter.metadata.firstWhere((e) {
+      final constantValue = e.computeConstantValue();
+      return TypeChecker.fromRuntime(CopyWithField)
+          .isExactlyType(constantValue.type);
+    }, orElse: () => null));
 
     if (copyWithFieldAnnotation != null) {
       final constantValue = copyWithFieldAnnotation.computeConstantValue();

--- a/copy_with_generator/lib/src/copy_with_generator.dart
+++ b/copy_with_generator/lib/src/copy_with_generator.dart
@@ -53,7 +53,7 @@ class CopyWithGenerator extends GeneratorForAnnotation<CopyWith> {
       final constantValue = e.computeConstantValue();
       return TypeChecker.fromRuntime(CopyWithField)
           .isExactlyType(constantValue.type);
-    }, orElse: () => () => element.getter.metadata.firstWhere((e) {
+    }, orElse: () => element.getter.metadata.firstWhere((e) {
       final constantValue = e.computeConstantValue();
       return TypeChecker.fromRuntime(CopyWithField)
           .isExactlyType(constantValue.type);

--- a/copy_with_generator/pubspec.yaml
+++ b/copy_with_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: copy_with
 description: Provides builder and generator for the copy_with_annotation package
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/thenextappnl/copy_with
 
 environment:


### PR DESCRIPTION
For example, equatable requires you to implement List<Object> get props => [], but the @CopyWithField(ignore: true) only is found in the element.getter.metadata, not in the element.metadata. 